### PR TITLE
R may31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ find_package(Threads REQUIRED)
 #   -lm    link math library
 #
 #   -DMACRO define MACRO:
-#     DEBUG               output debug information
-#     DPARTIAL_DATAFILES  write out some incomplete datafiles (for debug mainly)
+#     DETAILED_OUTPUT      print a lot of log information
+#     GENERAL_OUTPUT       print only main information
+#     PARTIAL_DATAFILES    write out some incomplete datafiles (for debug mainly)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}\
@@ -32,7 +33,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
             -g \
             -lm \
             -O3 \
-            -DDEBUG \
+            -DGENERAL_OUTPUT \
     ")
 endif (CMAKE_COMPILER_IS_GNUCXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,14 +47,20 @@ endif (CMAKE_COMPILER_IS_GNUCXX)
 
 set (HEADERS
     src/structure.hpp
-    src/options.hpp
+    src/options_common.hpp
     src/write_data.hpp
 )
 
 
-add_executable (isolated ${HEADERS} ${SOURCES} isolated.cpp)
+add_executable (isolated
+    ${HEADERS} src/options_isolated.hpp
+    isolated.cpp)
 
-add_executable (isolated_parallel ${HEADERS} ${SOURCES} isolated_parallel.cpp)
+add_executable (isolated_parallel
+    ${HEADERS} src/options_isolated_parallel.hpp
+    isolated_parallel.cpp)
 target_link_libraries(isolated_parallel Threads::Threads)
 
-add_executable (periodic ${HEADERS} ${SOURCES} periodic.cpp)
+add_executable (periodic
+    ${HEADERS} src/options_periodic.hpp
+    periodic.cpp)

--- a/demo_lmp_in
+++ b/demo_lmp_in
@@ -9,7 +9,7 @@ bond_style    harmonic
 neighbor      3 bin
 neigh_modify  delay 0 every 1 check no page 500000 one 50000
 
-read_data     periodic_mmt_edge10_mod_n40_tail2_poly_p10_n1408.data
+read_data     parallel_isolated_mmt_r10_n2_mod_n4_tail5_poly_p10_n6242.data
 mass          1 1
 mass          2 1.74
 mass          3 1.74
@@ -19,18 +19,19 @@ mass          4 1.74
 # n==0 - ok
 # alpha == 1 - ok1
 # cutoff == ...
-pair_style    hybrid/overlay coul/cut/soft 0 1 7 dpd 1 2 6668635
+pair_style    hybrid/overlay coul/cut/soft 0 1 7 dpd 1 1 6668635
 
-pair_coeff    1 1 dpd 0 5
-pair_coeff    1 2 dpd 100 5 1.72
-pair_coeff    1 3 dpd 100 5 1.72
-pair_coeff    1 4 dpd 100 5 1.72
-pair_coeff    2 2 dpd 1 5 1.72
-pair_coeff    2 3 dpd 1 5 1.72
-pair_coeff    2 4 dpd 1 5 1.72
-pair_coeff    3 3 dpd 1 5 1.72
-pair_coeff    3 4 dpd 1 5 1.72
-pair_coeff    4 4 dpd 1 5 1.72
+#
+pair_coeff    1 1 dpd 0 5 0.46
+pair_coeff    1 2 dpd 100 5 0.58
+pair_coeff    1 3 dpd 100 5 0.58
+pair_coeff    1 4 dpd 100 5 0.58
+pair_coeff    2 2 dpd 1 5 0.7
+pair_coeff    2 3 dpd 1 5 0.7
+pair_coeff    2 4 dpd 1 5 0.7
+pair_coeff    3 3 dpd 1 5 0.7
+pair_coeff    3 4 dpd 1 5 0.7
+pair_coeff    4 4 dpd 1 5 0.7
 
 #pair_coeff    * * coul/cut
 
@@ -38,28 +39,22 @@ pair_coeff    4 4 dpd 1 5 1.72
 # 0.5 ok
 pair_coeff    * * coul/cut/soft 0.5
 
-bond_coeff    1 100 2
-bond_coeff    2 100 3.4641016151377544
-bond_coeff    3 10 2
-bond_coeff    4 10 2
-bond_coeff    5 2 2
+bond_coeff    1 1000 0.92
+bond_coeff    2 1000 1.59
+bond_coeff    3 10 1.4
+bond_coeff    4 10 1.4
+bond_coeff    5 2 1.4
 
 thermo        10
 thermo_style  custom step density press pe ebond ecoul evdwl lz
 
-group         charged id 1:2940
-group         soft_rared id 2941:12730:100
+group         charged id 1:1276
+group         soft_rared id 1277:63696:1000
 group         imagable union charged soft_rared
 
-dump          d1 imagable image 1000 *.jpg type type view 90 0
+dump          d1 imagable image 10 *.jpg type type view 90 0
 
 timestep      0.01
 fix           1 all nvt temp 1 1 10000
 
-label loop
-variable a loop 500
-    run 5000 start 0 stop 2500000
-    write_data dpd.*.data
-    write_restart dpd.*.restart
-    next a
-jump SELF loop
+run 5000

--- a/demo_lmp_in
+++ b/demo_lmp_in
@@ -9,7 +9,7 @@ bond_style    harmonic
 neighbor      3 bin
 neigh_modify  delay 0 every 1 check no page 500000 one 50000
 
-read_data     parallel_isolated_mmt_r3_n2_mod_n2_tail5_poly_p10_n4089.data
+read_data     periodic_mmt_edge10_mod_n40_tail2_poly_p10_n1408.data
 mass          1 1
 mass          2 1.74
 mass          3 1.74

--- a/isolated.cpp
+++ b/isolated.cpp
@@ -12,11 +12,14 @@
 
 int main()
 {
-    bool verbose = true;
+    bool verbose = false;
+    #ifdef DETAILED_OUTPUT
+        verbose = true;
+    #endif
 
     // Parse options
     OptionsIsolated o("options_isolated");
-    #ifdef DEBUG
+    #ifdef DETAILED_OUTPUT  // Print all read options
       {
         std::cout << "**********\n";
         std::cout << "Parsed options:\n";
@@ -25,24 +28,10 @@ int main()
       }
     #endif
 
-    // Compute general parameters
-    float real_bead_radius = 1.35;
-    float real_cutoff = std::cbrt(o.dpd_rho * 4/3 * M_PI) * real_bead_radius;
-    float lj_interlayer = o.real_interlayer * o.lj_bead_radius / real_bead_radius;
-    #ifdef DEBUG
-      {
-        std::cout << "**********\n";
-        std::cout << "General parameters:\n";
-        std::cout << "real_bead_radius = " << real_bead_radius << std::endl;
-        std::cout << "real_cutoff = " << real_cutoff << std::endl;
-        std::cout << "lj_interlayer = " << lj_interlayer << std::endl;
-        std::cout << "**********\n";
-      }
-    #endif
-
 
     // Compute modifiers count per one lamella:
-    float real_mmt_area = M_PI * pow(o.platelet_radius * real_bead_radius, 2);
+    float real_mmt_bead_d(o.real_r_c * 2*o.lj_bead_radius_clay);
+    float real_mmt_area = M_PI * pow(o.platelet_radius * real_mmt_bead_d, 2);
     size_t charged_count;
     std::string modifier_count_taken_from;
     if (!o.modifiers_count_preset)
@@ -55,7 +44,7 @@ int main()
         charged_count = o.modifiers_count_preset;
         modifier_count_taken_from = "options";
       }
-    #ifdef DEBUG
+    #ifdef DETAILED_OUTPUT  // Print information about modifier
       {
         std::cout << "**********\n";
         std::cout << "Derived parameters:\n";
@@ -67,64 +56,64 @@ int main()
 
     // Compute box size
     float min_height = o.real_interlayer * o.stacking  // top and bottom
-        + 4 * real_bead_radius * o.stacking;
-    float min_width = 2*o.platelet_radius * 2*real_bead_radius
-        * std::max(float(o.planar_expansion_coeff), o.planar_expansion_coeff);
-    float cube_edge = std::max(min_width, min_height)
-        * o.lj_bead_radius / real_bead_radius;  // in lj units
-    #ifdef DEBUG
+        + 2 * real_mmt_bead_d * o.stacking;
+    float min_width = 2*o.platelet_radius * real_mmt_bead_d
+        * float(o.planar_expansion_coeff);
+    float cube_edge = std::max(min_width, min_height) / o.real_r_c;
+    #ifdef DETAILED_OUTPUT  // Print information about box
       {
         std::cout << "**********\n";
         std::cout << "Box computations:\n";
         std::cout << "min_height = " << min_height << std::endl;
         std::cout << "min_width = " << min_width << std::endl;
         std::cout << "cube_edge (in lj units) = " << cube_edge << std::endl;
-        std::cout << "mmt real radius: " << 2*o.lj_bead_radius *o.platelet_radius
-            << std::endl;
-        std::cout << "radii: " << o.lj_bead_radius << " " << real_bead_radius
-            << std::endl;
         std::cout << "**********\n";
       }
     #endif
 
     // Adjust polymers count:
-    float free_volume = pow(cube_edge, 3)
-        -4 * 4*pow(o.platelet_radius, 2) * pow(o.lj_bead_radius, 3)
-        -charged_count * (1 + o.tail_length) * 4*pow(o.lj_bead_radius, 3);
-    float polymer_volume = o.polymerization * pow(o.lj_bead_radius, 3);
-    size_t polymers_count = o.dpd_rho * free_volume / polymer_volume;
-    #ifdef DEBUG
+    float lj_cell_volume = pow(cube_edge, 3);
+    size_t all_beads_count = o.dpd_rho * lj_cell_volume;
+    size_t mmt_beads_count = 2 * size_t(M_PI * pow(o.platelet_radius, 2));
+    size_t single_mod_beads_count = 1 + o.tail_length;
+    size_t all_mods_beads_count = single_mod_beads_count * charged_count;
+    size_t single_polymer_beads_count = o.polymerization;
+    size_t polymers_count = round((all_beads_count
+        -mmt_beads_count - all_mods_beads_count) / o.polymerization);
+
+    #ifdef DETAILED_OUTPUT  // Print information about polymers
       {
         std::cout << "**********\n";
         std::cout << "Polymers computations:\n";
-        std::cout << "Free volume = " << free_volume << std::endl;
-        std::cout << "Polymer volume = " << polymer_volume << std::endl;
-        std::cout << "polymers_count = " << polymers_count << std::endl;
+        std::cout << "\tpolymers_count = " << polymers_count << std::endl;
         std::cout << "**********\n";
       }
     #endif
 
-    // Start main algorithm
+    // *************************************************************************
+    //                             Start main algorithm
+    // *************************************************************************
     Structure s;
 
-    // Set calcualted box
-    s.xlo = -cube_edge;
-    s.xhi = cube_edge;
-    s.ylo = -cube_edge;
-    s.yhi = cube_edge;
-    s.zlo = -cube_edge;
-    s.zhi = cube_edge;
+    // Set calcualted size to the box
+    s.xlo = -cube_edge/2;
+    s.xhi = cube_edge/2;
+    s.ylo = -cube_edge/2;
+    s.yhi = cube_edge/2;
+    s.zlo = -cube_edge/2;
+    s.zhi = cube_edge/2;
 
     // Add MMT stack
     size_t half_stacking = o.stacking / 2;
     size_t part_charged_count = charged_count / o.stacking;
     size_t charged_mmt_done = 0;
-    float dz = lj_interlayer / 2 + 2 * o.lj_bead_radius;
+    float lj_interlayer = o.real_interlayer / o.real_r_c;
+    float dz = lj_interlayer / 2 + 2*o.lj_bead_radius_clay;
     if (o.stacking % 2 != 0)
       {
         bool status = s.add_mmt_circular(o, 0, 0, 0, part_charged_count);
         charged_mmt_done += part_charged_count;
-        dz = lj_interlayer + 4 * o.lj_bead_radius;
+        dz = lj_interlayer + 4 * o.lj_bead_radius_clay;
       }
     for (size_t idx = 0; idx < half_stacking; ++idx)
       {
@@ -147,18 +136,28 @@ int main()
         bool status = s.add_mmt_circular(o, 0, 0, dz, part_charged_count1);
         charged_mmt_done += part_charged_count1;
         status = s.add_mmt_circular(o, 0, 0, -dz, part_charged_count2);
-        dz += lj_interlayer + 4 * o.lj_bead_radius;
+        dz += lj_interlayer + 4 * o.lj_bead_radius_clay;
         charged_mmt_done += part_charged_count2;
       }
     size_t mmt_atoms = s.atoms().size();
-    #ifdef DEBUG
+    #ifdef DETAILED_OUTPUT  // Print information about mmt addition status
       {
         std::cout << "**********\n";
         std::cout << "MMT addition:\n";
         std::cout << "atoms_count = " << s.atoms().size() << std::endl;
+        std::cout << "\ncharged_mmt_done: " << charged_mmt_done;
         std::cout << "**********\n";
-
-        //write_data("isolated_mmt.data", s);
+      }
+    #endif
+    #ifdef PARTIAL_DATAFILES  // Output incomplete data into file
+      {
+        std::string data_out_fname("incomplete_isolated_mmt");
+        data_out_fname += "_r" + std::to_string(o.platelet_radius);
+        data_out_fname += "_n" + std::to_string(o.stacking);
+        data_out_fname += ".data";
+        std::cout << "Writing incomplete data into " << data_out_fname
+            << std::endl;
+        write_data(data_out_fname, s);
       }
     #endif
 
@@ -169,7 +168,7 @@ int main()
         for (size_t idx = 0; idx < half_stacking; ++idx)
           {
             float top = lj_interlayer / 2
-                + idx * (lj_interlayer + 4 * o.lj_bead_radius);
+                + idx * (lj_interlayer + 4 * o.lj_bead_radius_clay);
             galleries.push_back(std::pair<float, float>(top - lj_interlayer, top));
           }
       }
@@ -177,8 +176,8 @@ int main()
       {
         for (size_t idx = 0; idx < half_stacking; ++idx)
           {
-            float top = lj_interlayer + 2 * o.lj_bead_radius
-                + idx * (lj_interlayer + 4 * o.lj_bead_radius);
+            float top = lj_interlayer + 2 * o.lj_bead_radius_clay
+                + idx * (lj_interlayer + 4 * o.lj_bead_radius_clay);
             galleries.push_back(std::pair<float, float>(top - lj_interlayer, top));
           }
       }
@@ -188,7 +187,7 @@ int main()
     while (modifiers_done < charged_count
         && modifiers_fails_done < modifiers_fails_allowed)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print information about last step
           {
             std::cout << "**********\n";
             std::cout << "Modifier addition: "
@@ -198,6 +197,7 @@ int main()
             std::cout << "**********\n";
           }
         #endif
+
         size_t idx = rand() % galleries.size();
         float bottom = galleries[idx].first;
         float top = galleries[idx].second;
@@ -211,17 +211,38 @@ int main()
             modifiers_fails_done ++;
           }
       }
+
+    if (modifiers_done != charged_count)
+      {
+        std::cout << "Failed to add all modifiers required\n";
+        return 0;
+      }
+
     size_t modifier_atoms = s.atoms().size() - mmt_atoms;
-    #ifdef DEBUG
+
+    #ifdef DETAILED_OUTPUT  // Print overall information about modifier addition
       {
         std::cout << "**********\n";
         std::cout << "Modifier addition after all: "
-                  <<  modifiers_done << " of " << charged_count
-                  << "; fais: " << modifiers_fails_done
-                  << " of " << modifiers_fails_allowed << "\n";
+            << "modifier_count_taken_from: " << modifier_count_taken_from
+            <<  modifiers_done << " of " << charged_count
+            << "; fais: " << modifiers_fails_done
+            << " of " << modifiers_fails_allowed << "\n";
         std::cout << "**********\n";
+      }
+    #endif
 
-        //write_data("isolated_mmt_mod.data", s);
+    #ifdef PARTIAL_DATAFILES  // Output incomplete data into file
+      {
+        std::string data_out_fname("incomplete_isolated_mmt");
+        data_out_fname += "_r" + std::to_string(o.platelet_radius);
+        data_out_fname += "_n" + std::to_string(o.stacking);
+        data_out_fname += "_mod_n" + std::to_string(modifiers_done);
+        data_out_fname += "_tail" + std::to_string(o.tail_length);
+        data_out_fname += ".data";
+        std::cout << "Writing incomplete data into " << data_out_fname
+            << std::endl;
+        write_data(data_out_fname, s);
       }
     #endif
 
@@ -231,7 +252,7 @@ int main()
     while (polymers_done < polymers_count
         && polymers_fails_done < polymers_fails_allowed)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print information about last step (sometimes)
         if (polymers_done % (size_t(polymers_count / 10)) == 0)
           {
             std::cout << "**********\n";
@@ -252,8 +273,14 @@ int main()
             polymers_fails_done ++;
           }
       }
+    if (polymers_done < polymers_count)
+      {
+        std::cout << "Failed to add all polymers required\n";
+        return 0;
+      }
     size_t polymer_atoms = s.atoms().size() - mmt_atoms - modifier_atoms;
-    #ifdef DEBUG
+
+    #ifdef DETAILED_OUTPUT  // Print overall information about polymer addition
       {
         std::cout << "**********\n";
         std::cout << "Polymers addition after all: "
@@ -264,6 +291,7 @@ int main()
       }
     #endif
 
+    // Write resulting datafile
     std::string data_out_fname("isolated_mmt");
     data_out_fname += "_r" + std::to_string(o.platelet_radius);
     data_out_fname += "_n" + std::to_string(o.stacking);
@@ -272,37 +300,36 @@ int main()
     data_out_fname += "_poly_p" + std::to_string(o.polymerization);
     data_out_fname += "_n" + std::to_string(polymers_done);
     data_out_fname += ".data";
-
-    //write_data("isolated_mmt_mod_poly.data", s);
     write_data(data_out_fname, s);
 
-    #ifdef DEBUG
+    #ifdef GENERAL_OUTPUT  // Print summary structural information
       {
-        std::cout << "Structure created:\n"
-            << "\tAtoms: " << s.atoms().size() << std::endl
-            << "\tBonds: " << s.bonds().size() << std::endl
-            << "\tBox side: " << cube_edge << std::endl
-            << "\tDPD_rho: " << s.atoms().size() / pow(cube_edge, 3) << std::endl;
-
-        std::cout
-            << "MMT: 1 - " << mmt_atoms << std::endl
-            << "modifier: " << mmt_atoms + 1 << " - "
+        std::cout << "Structure created:"
+            << "\n\tAtoms: " << s.atoms().size()
+            << "\n\tBonds: " << s.bonds().size()
+            << "\n\tCubic box side: " << cube_edge
+            << std::endl;
+        std::cout << "Atoms:"
+            << "\n\tMMT:      1 - " << mmt_atoms
+            << "\n\tmodifier: " << mmt_atoms + 1 << " - "
                 << mmt_atoms + modifier_atoms
-                << " (" << modifiers_done << ") molecules"
-                << " (" << modifier_count_taken_from << ")" << std::endl
-            << "polymer: " << mmt_atoms + modifier_atoms + 1 << " - "
+                << " (" << modifiers_done << " molecules)"
+                << " (" << modifier_count_taken_from << ")"
+            << "\n\tpolymer:  " << mmt_atoms + modifier_atoms + 1 << " - "
                 << mmt_atoms + modifier_atoms + polymer_atoms
-                << " (" << polymers_done << ") molecules" << std::endl;
-        std::cout << "result written into " << data_out_fname << std::endl;
+                << " (" << polymers_done << " molecules)" << std::endl;
+
+        std::cout << "Resulting structure written into:\n\t"
+            << data_out_fname << std::endl;
+
+        float DPD_rho = float(s.atoms().size())
+            / (s.xhi-s.xlo) / (s.yhi-s.ylo) / (s.zhi-s.zlo);
+        float CEC(real_mmt_area / 90 / 84 * 93 * 108/modifiers_done);
+        std::cout << "Physical parameters:\n"
+            << "\tDPD_rho (numerical): " << DPD_rho
+            << "\n\tCEC: " << CEC << std::endl;
       }
     #endif
-
-    std::cout << "modifier_count_taken_from: " << modifier_count_taken_from
-        << "\ncharged_count: " << charged_count
-        << "\ncharged_mmt_done: " << charged_mmt_done
-        << "\nmodifiers_done: " << modifiers_done
-        << "\nratio: " << charged_count / (0.015 * real_mmt_area * o.stacking) * 93
-        << std::endl;
 
     return 0;
 }

--- a/isolated.cpp
+++ b/isolated.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 
-#include "src/options.hpp"
+#include "src/options_isolated.hpp"
 #include "src/structure.hpp"
 #include "src/write_data.hpp"
 
@@ -15,7 +15,7 @@ int main()
     bool verbose = true;
 
     // Parse options
-    Options o("options_isolated");
+    OptionsIsolated o("options_isolated");
     #ifdef DEBUG
       {
         std::cout << "**********\n";
@@ -26,8 +26,6 @@ int main()
     #endif
 
     // Compute general parameters
-    float real_bead_radius2 = std::cbrt(o.lx * o.ly * (o.lz - o.mmt_real_thickness)
-        / o.md_soft_atoms / (4/3 * M_PI));
     float real_bead_radius = 1.35;
     float real_cutoff = std::cbrt(o.dpd_rho * 4/3 * M_PI) * real_bead_radius;
     float lj_interlayer = o.real_interlayer * o.lj_bead_radius / real_bead_radius;

--- a/isolated_parallel.cpp
+++ b/isolated_parallel.cpp
@@ -45,9 +45,13 @@ void threading_function(size_t thread_idx, Structure &s,
     while (polymers_done < polymers_count
         && polymers_fails_done < polymers_fails_allowed)
       {
+        #ifdef DETAILED_OUTPUT  // Information about thread's last step
         if (polymers_done % (size_t(polymers_count / 10)) == 0)
-        std::cout << thread_idx << " " << polymers_done << " " << polymers_count
-            << std::endl;
+          {
+            std::cout << thread_idx << " "
+                << polymers_done << " " << polymers_count << std::endl;
+          }
+        #endif
 
         bool status = s.add_polymer_parallel(o, idx_x, nx, idx_y, ny, idx_z, nz);
         if (status)
@@ -64,11 +68,14 @@ void threading_function(size_t thread_idx, Structure &s,
 
 int main()
 {
-    bool verbose = true;
+    bool verbose = false;
+    #ifdef DETAILED_OUTPUT
+        verbose = true;
+    #endif
 
     // Parse options
     OptionsIsolatedParallel o("options_isolated");
-    #ifdef DEBUG
+    #ifdef DETAILED_OUTPUT  // Print parsed options
       {
         std::cout << "**********\n";
         std::cout << "Parsed options:\n";
@@ -78,23 +85,11 @@ int main()
     #endif
 
     // Compute general parameters
-    float real_bead_radius = 1.35;
-    float real_cutoff = std::cbrt(o.dpd_rho * 4/3 * M_PI) * real_bead_radius;
-    float lj_interlayer = o.real_interlayer * o.lj_bead_radius / real_bead_radius;
-    #ifdef DEBUG
-      {
-        std::cout << "**********\n";
-        std::cout << "General parameters:\n";
-        std::cout << "real_bead_radius = " << real_bead_radius << std::endl;
-        std::cout << "real_cutoff = " << real_cutoff << std::endl;
-        std::cout << "lj_interlayer = " << lj_interlayer << std::endl;
-        std::cout << "**********\n";
-      }
-    #endif
-
+    float real_mmt_bead_d(o.real_r_c * 2*o.lj_bead_radius_clay);
+    float lj_interlayer = o.real_interlayer / o.real_r_c;
 
     // Compute modifiers count per one lamella:
-    float real_mmt_area = M_PI * pow(o.platelet_radius * real_bead_radius, 2);
+    float real_mmt_area = M_PI * pow(o.platelet_radius * real_mmt_bead_d, 2);
     size_t charged_count;
     std::string modifier_count_taken_from;
     if (!o.modifiers_count_preset)
@@ -107,7 +102,8 @@ int main()
         charged_count = o.modifiers_count_preset;
         modifier_count_taken_from = "options";
       }
-    #ifdef DEBUG
+
+    #ifdef DETAILED_OUTPUT  // Print parameters of MMT and modifier charges
       {
         std::cout << "**********\n";
         std::cout << "Derived parameters:\n";
@@ -118,65 +114,65 @@ int main()
     #endif
 
     // Compute box size
-    float min_height = o.real_interlayer * o.stacking  // top and bottom
-        + 4 * real_bead_radius * o.stacking;
-    float min_width = 2*o.platelet_radius * 2*real_bead_radius
-        * std::max(float(o.planar_expansion_coeff), o.planar_expansion_coeff);
-    float cube_edge = std::max(min_width, min_height)
-        * o.lj_bead_radius / real_bead_radius;  // in lj units
-    #ifdef DEBUG
+    float min_height = o.real_interlayer * o.stacking
+        + 2 * real_mmt_bead_d * o.stacking;
+    float min_width = 2*o.platelet_radius * real_mmt_bead_d
+        * float(o.planar_expansion_coeff);
+    float cube_edge = std::max(min_width, min_height) / o.real_r_c;
+
+    #ifdef DETAILED_OUTPUT  // Print box infomation
       {
         std::cout << "**********\n";
         std::cout << "Box computations:\n";
         std::cout << "min_height = " << min_height << std::endl;
         std::cout << "min_width = " << min_width << std::endl;
         std::cout << "cube_edge (in lj units) = " << cube_edge << std::endl;
-        std::cout << "mmt real radius: " << 2*o.lj_bead_radius *o.platelet_radius
-            << std::endl;
-        std::cout << "radii: " << o.lj_bead_radius << " " << real_bead_radius
-            << std::endl;
         std::cout << "**********\n";
       }
     #endif
 
     // Adjust polymers count:
-    float free_volume = pow(cube_edge, 3)
-        -4 * 4*pow(o.platelet_radius, 2) * pow(o.lj_bead_radius, 3)
-        -charged_count * (1 + o.tail_length) * 4*pow(o.lj_bead_radius, 3);
-    float polymer_volume = o.polymerization * pow(o.lj_bead_radius, 3);
-    size_t polymers_count = o.dpd_rho * free_volume / polymer_volume;
-    #ifdef DEBUG
+    float lj_cell_volume = pow(cube_edge, 3);
+    size_t all_beads_count = o.dpd_rho * lj_cell_volume;
+    size_t mmt_beads_count = 2 * size_t(M_PI * pow(o.platelet_radius, 2));
+    size_t single_mod_beads_count = 1 + o.tail_length;
+    size_t all_mods_beads_count = single_mod_beads_count * charged_count;
+    size_t single_polymer_beads_count = o.polymerization;
+    size_t polymers_count = round((all_beads_count
+        -mmt_beads_count - all_mods_beads_count) / o.polymerization);
+
+    #ifdef DETAILED_OUTPUT  // Print polymer addition parameters
       {
         std::cout << "**********\n";
         std::cout << "Polymers computations:\n";
-        std::cout << "Free volume = " << free_volume << std::endl;
-        std::cout << "Polymer volume = " << polymer_volume << std::endl;
         std::cout << "polymers_count = " << polymers_count << std::endl;
         std::cout << "**********\n";
       }
     #endif
 
-    // Start main algorithm
+    // *************************************************************************
+    //                             Start main algorithm
+    // *************************************************************************
     Structure s;
 
     // Set calcualted box
-    s.xlo = -cube_edge;
-    s.xhi = cube_edge;
-    s.ylo = -cube_edge;
-    s.yhi = cube_edge;
-    s.zlo = -cube_edge;
-    s.zhi = cube_edge;
+    s.xlo = -cube_edge/2;
+    s.xhi = cube_edge/2;
+    s.ylo = -cube_edge/2;
+    s.yhi = cube_edge/2;
+    s.zlo = -cube_edge/2;
+    s.zhi = cube_edge/2;
 
     // Add MMT stack
     size_t half_stacking = o.stacking / 2;
     size_t part_charged_count = charged_count / o.stacking;
     size_t charged_mmt_done = 0;
-    float dz = lj_interlayer / 2 + 2 * o.lj_bead_radius;
+    float dz = lj_interlayer / 2 + 2*o.lj_bead_radius_clay;
     if (o.stacking % 2 != 0)
       {
         bool status = s.add_mmt_circular(o, 0, 0, 0, part_charged_count);
         charged_mmt_done += part_charged_count;
-        dz = lj_interlayer + 4 * o.lj_bead_radius;
+        dz = lj_interlayer + 4 * o.lj_bead_radius_clay;
       }
     for (size_t idx = 0; idx < half_stacking; ++idx)
       {
@@ -199,18 +195,27 @@ int main()
         bool status = s.add_mmt_circular(o, 0, 0, dz, part_charged_count1);
         charged_mmt_done += part_charged_count1;
         status = s.add_mmt_circular(o, 0, 0, -dz, part_charged_count2);
-        dz += lj_interlayer + 4 * o.lj_bead_radius;
+        dz += lj_interlayer + 4 * o.lj_bead_radius_clay;
         charged_mmt_done += part_charged_count2;
       }
     size_t mmt_atoms = s.atoms().size();
-    #ifdef DEBUG
+
+    #ifdef DETAILED_OUTPUT  // Print results of MMT addition
       {
         std::cout << "**********\n";
         std::cout << "MMT addition:\n";
         std::cout << "atoms_count = " << s.atoms().size() << std::endl;
         std::cout << "**********\n";
+      }
+    #endif
 
-        //write_data("isolated_mmt.data", s);
+    #ifdef PARTIAL_DATAFILES
+      {
+        std::string data_out_fname("incomlete_parallel_isolated_mmt");
+        data_out_fname += "_r" + std::to_string(o.platelet_radius);
+        data_out_fname += "_n" + std::to_string(o.stacking);
+        data_out_fname += ".data";
+        write_data(data_out_fname, s);
       }
     #endif
 
@@ -221,7 +226,7 @@ int main()
         for (size_t idx = 0; idx < half_stacking; ++idx)
           {
             float top = lj_interlayer / 2
-                + idx * (lj_interlayer + 4 * o.lj_bead_radius);
+                + idx * (lj_interlayer + 4 * o.lj_bead_radius_clay);
             galleries.push_back(std::pair<float, float>(top - lj_interlayer, top));
           }
       }
@@ -229,8 +234,8 @@ int main()
       {
         for (size_t idx = 0; idx < half_stacking; ++idx)
           {
-            float top = lj_interlayer + 2 * o.lj_bead_radius
-                + idx * (lj_interlayer + 4 * o.lj_bead_radius);
+            float top = lj_interlayer + 2 * o.lj_bead_radius_clay
+                + idx * (lj_interlayer + 4 * o.lj_bead_radius_clay);
             galleries.push_back(std::pair<float, float>(top - lj_interlayer, top));
           }
       }
@@ -240,7 +245,7 @@ int main()
     while (modifiers_done < charged_count
         && modifiers_fails_done < modifiers_fails_allowed)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print information about last step
           {
             std::cout << "**********\n";
             std::cout << "Modifier addition: "
@@ -250,6 +255,7 @@ int main()
             std::cout << "**********\n";
           }
         #endif
+
         size_t idx = rand() % galleries.size();
         float bottom = galleries[idx].first;
         float top = galleries[idx].second;
@@ -263,8 +269,16 @@ int main()
             modifiers_fails_done ++;
           }
       }
+
+    if (modifiers_done != charged_count)
+      {
+        std::cout << "Failed to add modifier\n";
+        return 0;
+      }
+
     size_t modifier_atoms = s.atoms().size() - mmt_atoms;
-    #ifdef DEBUG
+
+    #ifdef DETAILED_INFORMATION  // Print results of modifiers addition
       {
         std::cout << "**********\n";
         std::cout << "Modifier addition after all: "
@@ -272,8 +286,18 @@ int main()
                   << "; fais: " << modifiers_fails_done
                   << " of " << modifiers_fails_allowed << "\n";
         std::cout << "**********\n";
+      }
+    #endif
 
-        //write_data("isolated_mmt_mod.data", s);
+    #ifdef PARTIAL_DATAFILES
+      {
+        std::string data_out_fname("incomplete_parallel_isolated_mmt");
+        data_out_fname += "_r" + std::to_string(o.platelet_radius);
+        data_out_fname += "_n" + std::to_string(o.stacking);
+        data_out_fname += "_mod_n" + std::to_string(modifiers_done);
+        data_out_fname += "_tail" + std::to_string(o.tail_length);
+        data_out_fname += ".data";
+        write_data(data_out_fname, s);
       }
     #endif
 
@@ -313,7 +337,7 @@ int main()
         while (polymers_done < polymers_count
             && polymers_fails_done < polymers_fails_allowed)
           {
-            #ifdef DEBUG
+            #ifdef DETAILED_OUTPUT  // Print information about last step
               {
                 std::cout << "**********\n";
                 std::cout << "Polymer addition: "
@@ -335,7 +359,7 @@ int main()
           }
       }
 
-    #ifdef DEBUG
+    #ifdef DETAILED_OUTPUT  // Print overall information about polymer addition
       {
         std::cout << "**********\n";
         std::cout << "Polymers addition after all: "
@@ -352,37 +376,38 @@ int main()
     data_out_fname += "_poly_p" + std::to_string(o.polymerization);
     data_out_fname += "_n" + std::to_string(polymers_done);
     data_out_fname += ".data";
-
-    //write_data("isolated_mmt_mod_poly.data", s);
     write_data(data_out_fname, s);
 
-    #ifdef DEBUG
+    #ifdef GENERAL_OUTPUT
       {
         std::cout << "Structure created:\n"
             << "\tAtoms: " << s.atoms().size() << std::endl
             << "\tBonds: " << s.bonds().size() << std::endl
-            << "\tBox side: " << cube_edge << std::endl
-            << "\tDPD_rho: " << s.atoms().size() / pow(cube_edge, 3) << std::endl;
-
-        std::cout
-            << "MMT: 1 - " << mmt_atoms << std::endl
-            << "modifier: " << mmt_atoms + 1 << " - "
+            << "\tCubic box side: " << cube_edge << std::endl;
+        std::cout << "Atoms:"
+            << "\n\tMMT:      1 - " << mmt_atoms
+            << "\n\tmodifier: " << mmt_atoms + 1 << " - "
                 << mmt_atoms + modifier_atoms
-                << " (" << modifiers_done << ") molecules"
-                << " (" << modifier_count_taken_from << ")" << std::endl
-            << "polymer: " << mmt_atoms + modifier_atoms + 1 << " - "
-                << mmt_atoms + modifier_atoms + polymer_atoms
-                << " (" << polymers_done << ") molecules" << std::endl;
-        std::cout << "result written into " << data_out_fname << std::endl;
+                << " (" << modifiers_done << " molecules)"
+                << " (" << modifier_count_taken_from << ")"
+            << "\n\tpolymer:  " << mmt_atoms + modifier_atoms + 1 << " - "
+                << s.atoms().size()
+                << " (" << polymers_done << " molecules)" << std::endl;
+        std::cout << "Resulting structure written into:\n\t"
+            << data_out_fname << std::endl;
       }
     #endif
 
-    std::cout << "modifier_count_taken_from: " << modifier_count_taken_from
-        << "\ncharged_count: " << charged_count
-        << "\ncharged_mmt_done: " << charged_mmt_done
-        << "\nmodifiers_done: " << modifiers_done
-        << "\nratio: " << charged_count / (0.015 * real_mmt_area * o.stacking) * 93
-        << std::endl;
+    #ifdef GENERAL_OUTPUT  // Print DPD_rho and CEC
+      {
+        float DPD_rho = float(s.atoms().size())
+            / (s.xhi-s.xlo) / (s.yhi-s.ylo) / (s.zhi-s.zlo);
+        float CEC(real_mmt_area / 90 / 84 * 93 * 108/modifiers_done);
+        std::cout << "Physical parameters:\n"
+            << "\tDPD_rho (numerical): " << DPD_rho
+            << "\n\tCEC: " << CEC << std::endl;
+      }
+    #endif
 
     return 0;
 }

--- a/isolated_parallel.cpp
+++ b/isolated_parallel.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <thread>
 
-#include "src/options.hpp"
+#include "src/options_isolated_parallel.hpp"
 #include "src/structure.hpp"
 #include "src/write_data.hpp"
 
@@ -30,8 +30,9 @@ std::array<size_t, 3> one2three(size_t idx1d, size_t nx, size_t ny, size_t nz)
 }
 
 
-void threading_function(size_t thread_idx, Structure &s, Options &o,
-size_t nx, size_t ny, size_t nz, size_t polymers_count)
+void threading_function(size_t thread_idx, Structure &s,
+    OptionsIsolatedParallel &o,
+    size_t nx, size_t ny, size_t nz, size_t polymers_count)
 {
     std::array<size_t, 3> idcs3d = one2three(thread_idx, nx, ny, nz);
     size_t idx_x = idcs3d[0];
@@ -66,7 +67,7 @@ int main()
     bool verbose = true;
 
     // Parse options
-    Options o("options_isolated");
+    OptionsIsolatedParallel o("options_isolated");
     #ifdef DEBUG
       {
         std::cout << "**********\n";

--- a/options_isolated
+++ b/options_isolated
@@ -1,7 +1,7 @@
 # Threads count for parallel version is nx*ny*nz
-nx 2
-ny 2
-nz 1
+threads_nx 2
+threads_ny 2
+threads_nz 1
 
 # Thickness of MMT platelet in Angstoms
 mmt_real_thickness 8
@@ -10,7 +10,7 @@ mmt_real_thickness 8
 planar_expansion_coeff 1.5
 
 # Radius of MMT platelet in beads if isolated algorithm is used
-platelet_radius 2
+platelet_radius 3
 
 # Length of the modifier tail in beads
 tail_length 5
@@ -19,7 +19,7 @@ tail_length 5
 bead_charge 10
 
 # Number of modifiers (may contradict to CEC and has higher priority)
-modifiers_count_preset 1
+modifiers_count_preset 4
 
 # Number of platelets in the stack
 stacking 2
@@ -34,7 +34,11 @@ real_interlayer 5
 dpd_rho 3
 
 # Bead radius in the lj units
-lj_bead_radius 1
+lj_bead_radius_clay 0.46
+lj_bead_radius_soft 0.70
+
+# Real rdaius of DPD cutoff
+real_r_c 5.23
 
 # Types of beads and bonds
 mmt_atom_type 1
@@ -48,8 +52,8 @@ polymer_atom_type 4
 polymer_bond_type 5
 
 # Minimal allowed distance between beads (to mmt and to soft phase)
-too_close_threshold_mmt 2
-too_close_threshold_soft 0.25
+too_close_threshold_mmt 1
+too_close_threshold_soft 0.01
 
 # Bond lengths
 modifier_head_tail_bond_length 2

--- a/options_isolated
+++ b/options_isolated
@@ -10,7 +10,7 @@ mmt_real_thickness 8
 planar_expansion_coeff 1.5
 
 # Radius of MMT platelet in beads if isolated algorithm is used
-platelet_radius 10
+platelet_radius 2
 
 # Length of the modifier tail in beads
 tail_length 5
@@ -19,7 +19,7 @@ tail_length 5
 bead_charge 10
 
 # Number of modifiers (may contradict to CEC and has higher priority)
-modifiers_count_preset 60
+modifiers_count_preset 1
 
 # Number of platelets in the stack
 stacking 2

--- a/options_periodic
+++ b/options_periodic
@@ -2,7 +2,7 @@
 mmt_real_thickness 8
 
 # Edge length of MMT platelets in beads if periodic algorithm is used
-platelet_edge 10
+platelet_edge 5
 
 # Length of the modifier tail in beads
 tail_length 2
@@ -11,7 +11,7 @@ tail_length 2
 bead_charge 10
 
 # Number of modifiers (may contradict to CEC and has higher priority)
-modifiers_count_preset 40
+modifiers_count_preset 4
 
 # Polymer length in monomer (or in beads because 1 monomer == 1 bead)
 polymerization 10
@@ -23,7 +23,11 @@ real_interlayer 5
 dpd_rho 3
 
 # Bead radius in the lj units
-lj_bead_radius 1
+lj_bead_radius_clay 0.46
+lj_bead_radius_soft 0.70
+
+# Real rdaius of DPD cutoff
+real_r_c 5.23
 
 # Types of beads and bonds
 mmt_atom_type 1
@@ -37,8 +41,8 @@ polymer_atom_type 4
 polymer_bond_type 5
 
 # Minimal allowed distance between beads (to mmt and to soft phase)
-too_close_threshold_mmt 2
-too_close_threshold_soft 0.25
+too_close_threshold_mmt 0.1
+too_close_threshold_soft 0.01
 
 # Bond lengths
 modifier_head_tail_bond_length 2

--- a/periodic.cpp
+++ b/periodic.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 
-#include "src/options.hpp"
+#include "src/options_periodic.hpp"
 #include "src/structure.hpp"
 #include "src/write_data.hpp"
 
@@ -15,7 +15,7 @@ int main()
     bool verbose = true;
 
     // Parse options
-    Options o("options_periodic");
+    OptionsPeriodic o("options_periodic");
     #ifdef DEBUG
       {
         // Output for checking wether parsed options are read correctly

--- a/src/options_common.hpp
+++ b/src/options_common.hpp
@@ -1,5 +1,5 @@
-#ifndef OPTIONS_HPP
-#define OPTIONS_HPP
+#ifndef OPTIONS_COMMON_HPP
+#define OPTIONS_COMMON_HPP
 
 
 #include <iostream>
@@ -8,13 +8,10 @@
 #include <string>
 
 
-class Options
+class OptionsCommon
 {
 public:
-    size_t md_soft_atoms = 0;
-    size_t platelet_radius = 0;
     size_t tail_length = 0;
-    size_t stacking = 0;
     size_t polymerization = 0;
     size_t mmt_atom_type = 0;
     size_t mmt_edge_bond_type = 0;
@@ -25,56 +22,34 @@ public:
     size_t tail_tail_type = 0;
     size_t polymer_atom_type = 0;
     size_t polymer_bond_type = 0;
-    size_t platelet_edge = 0;
     size_t modifiers_count_preset = 0;
-    size_t threads_nx = 1;
-    size_t threads_ny = 1;
-    size_t threads_nz = 1;
-    float lx = -1;
-    float ly = -1;
-    float lz = -1;
     float mmt_real_thickness = -1;
-    float planar_expansion_coeff = -1;
     float bead_charge = -1;
     float real_interlayer = -1;
     float dpd_rho = -1;
-    float lj_bead_radius = -1;
+    float lj_bead_radius = -1;  // TODO -> split into Soft and Clay
     float too_close_threshold_mmt = -1;
     float too_close_threshold_soft = -1;
     float modifier_head_tail_bond_length = -1;
     float modifier_tail_tail_bond_length = -1;
     float polymer_bond_length = -1;
 
-    Options(std::string options_fname)
+    OptionsCommon(std::string options_fname)
       {
         std::string option_name;
         std::ifstream ofs(options_fname);
         while (ofs >> option_name)
           {
-            if (option_name == "lx")
-                ofs >> this->lx;
-            else if (option_name == "ly")
-                ofs >> this->ly;
-            else if (option_name == "lz")
-                ofs >> this->lz;
-            else if (option_name == "mmt_real_thickness")
+            if (option_name == "mmt_real_thickness")
                 ofs >> this->mmt_real_thickness;
-            else if (option_name == "planar_expansion_coeff")
-                ofs >> this->planar_expansion_coeff;
             else if (option_name == "bead_charge")
                 ofs >> this->bead_charge;
             else if (option_name == "real_interlayer")
                 ofs >> this->real_interlayer;
             else if (option_name == "dpd_rho")
                 ofs >> this->dpd_rho;
-            else if (option_name == "md_soft_atoms")
-                ofs >> this->md_soft_atoms;
-            else if (option_name == "platelet_radius")
-                ofs >> this->platelet_radius;
             else if (option_name == "tail_length")
                 ofs >> this->tail_length;
-            else if (option_name == "stacking")
-                ofs >> this->stacking;
             else if (option_name == "polymerization")
                 ofs >> this->polymerization;
             else if (option_name == "lj_bead_radius")
@@ -107,44 +82,16 @@ public:
                 ofs >> this->polymer_atom_type;
             else if (option_name == "polymer_bond_type")
                 ofs >> this->polymer_bond_type;
-            else if (option_name == "platelet_edge")
-                ofs >> this->platelet_edge;
             else if (option_name == "modifiers_count_preset")
                 ofs >> this->modifiers_count_preset;
-            else if (option_name == "nx")
-                ofs >> this->threads_nx;
-            else if (option_name == "ny")
-                ofs >> this->threads_ny;
-            else if (option_name == "nz")
-                ofs >> this->threads_nz;
           }
       };
 
     void print_options(bool verbose=false)
       {
-        std::cout << "lx = " << this->lx;
-        if (verbose)
-            std::cout << " Cell length along x axis\n";
-        else
-            std::cout << std::endl;
-        std::cout << "ly = " << this->ly;
-        if (verbose)
-            std::cout << " Cell length along y axis\n";
-        else
-            std::cout << std::endl;
-        std::cout << "lz = " << this->lz;
-        if (verbose)
-            std::cout << " Cell length along z axis\n";
-        else
-            std::cout << std::endl;
         std::cout << "mmt_real_thickness = " << this->mmt_real_thickness;
         if (verbose)
             std::cout << " Thickness of a single MMT platelet (in Angstroms)\n";
-        else
-            std::cout << std::endl;
-        std::cout << "planar_expansion_coeff = " << this->planar_expansion_coeff;
-        if (verbose)
-            std::cout << " Cell increase coeff in xy plane around MMT platelet\n";
         else
             std::cout << std::endl;
         std::cout << "bead_charge = " << this->bead_charge;
@@ -162,24 +109,9 @@ public:
             std::cout << " DPD density (beads count / volume)\n";
         else
             std::cout << std::endl;
-        std::cout << "md_soft_atoms = " << this->md_soft_atoms;
-        if (verbose)
-            std::cout << " Count of soft atoms in composite from our MD\n";
-        else
-            std::cout << std::endl;
-        std::cout << "platelet_radius = " << this->platelet_radius;
-        if (verbose)
-            std::cout << " Radius of MMT platelet (in beads)\n";
-        else
-            std::cout << std::endl;
         std::cout << "tail_length = " << this->tail_length;
         if (verbose)
             std::cout << " Length of modifier's tail (in beads)\n";
-        else
-            std::cout << std::endl;
-        std::cout << "stacking = " << this->stacking;
-        if (verbose)
-            std::cout << " MMT platelets count in the stack\n";
         else
             std::cout << std::endl;
         std::cout << "polymerization = " << this->polymerization;
@@ -265,34 +197,13 @@ public:
             std::cout << " Type of all bonds in polymer\n";
         else
             std::cout << std::endl;
-        std::cout << "platelet_edge = "  << this->platelet_edge;
-        if (verbose)
-            std::cout << " Size of periodic MMT platelet\n";
-        else
-            std::cout << std::endl;
         std::cout << "modifiers_count_preset = " << this->modifiers_count_preset;
         if (verbose)
             std::cout << " Preset number of modifiers\n";
-        else
-            std::cout << std::endl;
-
-        std::cout << "threads_nx = " << this->threads_nx;
-        if (verbose)
-            std::cout << " Preset number of threads along x\n";
-        else
-            std::cout << std::endl;
-        std::cout << "threads_ny = " << this->threads_ny;
-        if (verbose)
-            std::cout << " Preset number of threads along y\n";
-        else
-            std::cout << std::endl;
-        std::cout << "threads_nz = " << this->threads_nz;
-        if (verbose)
-            std::cout << " Preset number of threads along z\n";
         else
             std::cout << std::endl;
       }
 };
 
 
-#endif  // OPTIONS_HPP
+#endif  // OPTIONS_COMMON_HPP

--- a/src/options_common.hpp
+++ b/src/options_common.hpp
@@ -27,7 +27,9 @@ public:
     float bead_charge = -1;
     float real_interlayer = -1;
     float dpd_rho = -1;
-    float lj_bead_radius = -1;  // TODO -> split into Soft and Clay
+    float real_r_c = -1;
+    float lj_bead_radius_clay = -1;
+    float lj_bead_radius_soft = -1;
     float too_close_threshold_mmt = -1;
     float too_close_threshold_soft = -1;
     float modifier_head_tail_bond_length = -1;
@@ -42,6 +44,8 @@ public:
           {
             if (option_name == "mmt_real_thickness")
                 ofs >> this->mmt_real_thickness;
+            else if (option_name == "real_r_c")
+                ofs >> this->real_r_c;
             else if (option_name == "bead_charge")
                 ofs >> this->bead_charge;
             else if (option_name == "real_interlayer")
@@ -52,8 +56,12 @@ public:
                 ofs >> this->tail_length;
             else if (option_name == "polymerization")
                 ofs >> this->polymerization;
-            else if (option_name == "lj_bead_radius")
-                ofs >> this->lj_bead_radius;
+            //else if (option_name == "lj_bead_radius")
+            //    ofs >> this->lj_bead_radius;
+            else if (option_name == "lj_bead_radius_clay")
+                ofs >> this->lj_bead_radius_clay;
+            else if (option_name == "lj_bead_radius_soft")
+                ofs >> this->lj_bead_radius_soft;
             else if (option_name == "mmt_atom_type")
                 ofs >> this->mmt_atom_type;
             else if (option_name == "mmt_edge_bond_type")
@@ -119,9 +127,14 @@ public:
             std::cout << " Polymerization degree (in monomers)\n";
         else
             std::cout << std::endl;
-        std::cout << "lj_bead_radius = " << this->lj_bead_radius;
+        std::cout << "lj_bead_radius_clay = " << this->lj_bead_radius_clay;
         if (verbose)
-            std::cout << " Bead radius in lj units\n";
+            std::cout << " Bead radius of clay in lj units\n";
+        else
+            std::cout << std::endl;
+        std::cout << "lj_bead_radius_soft = " << this->lj_bead_radius_soft;
+        if (verbose)
+            std::cout << " Bead radius of soft in lj units\n";
         else
             std::cout << std::endl;
         std::cout << "mmt_atom_type = " << this->mmt_atom_type;
@@ -200,6 +213,11 @@ public:
         std::cout << "modifiers_count_preset = " << this->modifiers_count_preset;
         if (verbose)
             std::cout << " Preset number of modifiers\n";
+        else
+            std::cout << std::endl;
+        std::cout << "real_r_c = " << this->real_r_c;
+        if (verbose)
+            std::cout << " DPD cutoff in real units\n";
         else
             std::cout << std::endl;
       }

--- a/src/options_isolated.hpp
+++ b/src/options_isolated.hpp
@@ -1,0 +1,61 @@
+#ifndef OPTIONS_ISOLATED_HPP
+#define OPTIONS_ISOLATED_HPP
+
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+
+#include "options_common.hpp"
+
+
+class OptionsIsolated : public OptionsCommon
+{
+public:
+    size_t platelet_radius = 0;
+    size_t stacking = 0;
+    float planar_expansion_coeff = -1;
+
+    OptionsIsolated(std::string options_fname)
+        : OptionsCommon(options_fname)
+      {
+        std::string option_name;
+        std::ifstream ofs(options_fname);
+        while (ofs >> option_name)
+          {
+            if (option_name == "planar_expansion_coeff")
+                ofs >> this->planar_expansion_coeff;
+            else if (option_name == "dpd_rho")
+                ofs >> this->dpd_rho;
+            else if (option_name == "platelet_radius")
+                ofs >> this->platelet_radius;
+            else if (option_name == "stacking")
+                ofs >> this->stacking;
+          }
+      };
+
+    void print_options(bool verbose=false)
+      {
+        OptionsCommon::print_options(verbose);
+
+        std::cout << "planar_expansion_coeff = " << this->planar_expansion_coeff;
+        if (verbose)
+            std::cout << " Cell increase coeff in xy plane around MMT platelet\n";
+        else
+            std::cout << std::endl;
+        std::cout << "platelet_radius = " << this->platelet_radius;
+        if (verbose)
+            std::cout << " Radius of MMT platelet (in beads)\n";
+        else
+            std::cout << std::endl;
+        std::cout << "stacking = " << this->stacking;
+        if (verbose)
+            std::cout << " MMT platelets count in the stack\n";
+        else
+            std::cout << std::endl;
+      }
+};
+
+
+#endif  // OPTIONS_ISOLATED_HPP

--- a/src/options_isolated_parallel.hpp
+++ b/src/options_isolated_parallel.hpp
@@ -1,0 +1,59 @@
+#ifndef OPTIONS_ISOLATED_PARALLEL_HPP
+#define OPTIONS_ISOLATED_PARALLEL_HPP
+
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+
+#include "options_isolated.hpp"
+
+
+class OptionsIsolatedParallel : public OptionsIsolated
+{
+public:
+    size_t threads_nx = 0;
+    size_t threads_ny = 0;
+    size_t threads_nz = 0;
+
+    OptionsIsolatedParallel(std::string options_fname)
+        : OptionsIsolated(options_fname)
+      {
+        std::string option_name;
+        std::ifstream ofs(options_fname);
+        while (ofs >> option_name)
+          {
+            if (option_name == "threads_nx")
+                ofs >> this->threads_nx;
+            else if (option_name == "threads_ny")
+                ofs >> this->threads_ny;
+            else if (option_name == "threads_nz")
+                ofs >> this->threads_nz;
+          }
+      };
+
+    void print_options(bool verbose=false)
+      {
+        OptionsIsolated::print_options(verbose);
+
+        std::cout << "threads_nx = " << this->threads_nx;
+        if (verbose)
+            std::cout << " Threads along x\n";
+        else
+            std::cout << std::endl;
+        std::cout << "threads_ny = " << this->threads_ny;
+        if (verbose)
+            std::cout << " Threads along y\n";
+        else
+            std::cout << std::endl;
+        std::cout << "threads_nz = " << this->threads_nz;
+        if (verbose)
+            std::cout << " Threads along z\n";
+        else
+            std::cout << std::endl;
+      }
+};
+
+
+#endif  // OPTIONS_ISOLATED_PARALLEL_HPP

--- a/src/options_periodic.hpp
+++ b/src/options_periodic.hpp
@@ -1,0 +1,42 @@
+#ifndef OPTIONS_PERIODIC_HPP
+#define OPTIONS_PERIODIC_HPP
+
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+
+#include "options_common.hpp"
+
+class OptionsPeriodic : public OptionsCommon
+{
+public:
+    size_t platelet_edge = 0;
+
+    OptionsPeriodic(std::string options_fname)
+        : OptionsCommon(options_fname)
+      {
+        std::string option_name;
+        std::ifstream ofs(options_fname);
+        while (ofs >> option_name)
+          {
+            if (option_name == "platelet_edge")
+                ofs >> this->platelet_edge;
+          }
+      };
+
+    void print_options(bool verbose=false)
+      {
+        OptionsCommon::print_options(verbose);
+
+        std::cout << "platelet_edge = " << this->platelet_edge;
+        if (verbose)
+            std::cout << " MMT platelet edge in beads\n";
+        else
+            std::cout << std::endl;
+      }
+};
+
+
+#endif  // OPTIONS_PERIODIC_HPP

--- a/src/structure.hpp
+++ b/src/structure.hpp
@@ -16,9 +16,9 @@
 #include "options_periodic.hpp"
 #include "options_isolated.hpp"
 #include "options_isolated_parallel.hpp"
-//class Options;
 
 
+// A simple container class for atom properties
 struct Atom
 {
 public:
@@ -41,6 +41,7 @@ public:
 };
 
 
+// A simple container class for bond properties
 struct Bond
 {
 public:
@@ -56,6 +57,7 @@ public:
 };
 
 
+// A very big class for storing and creating composite structure
 class Structure
 {
 public:
@@ -80,38 +82,39 @@ public:
         return this->_bonds;
       }
 
+    // Add an infinite (because of periodic boundary conditions) MMT platelet
     bool add_mmt_circular(OptionsIsolated &o,
         float x=0, float y=0, float z=0, size_t charged_count=0)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print parameters of MMT additions
         {
-            std::cout << "**********\n";
-            std::cout << "Structure.hpp add_mmt_circular input parameters:\n";
-            std::cout << "platelet_radius = " << o.platelet_radius << std::endl;
-            std::cout << "bead_radius = " << o.lj_bead_radius << std::endl;
-            std::cout << "atom_type = " << o.mmt_atom_type << std::endl;
-            std::cout << "mmt_edge_bond_type = "
-                << o.mmt_edge_bond_type << std::endl;
-            std::cout << "mmt_diagonal_bond_type = " << o.mmt_diagonal_bond_type
-                << std::endl;
-            std::cout << "x = " << x << std::endl;
-            std::cout << "y = " << y << std::endl;
-            std::cout << "z = " << z << std::endl;
-            std::cout << "charged_count = " << charged_count << std::endl;
-            std::cout << "bead_charge = " << o.bead_charge << std::endl;
-            std::cout << "**********\n";
+            std::cout << "**********\n"
+                << "\nStructure.hpp add_mmt_circular input parameters:\n"
+                << "\nplatelet_radius = " << o.platelet_radius
+                << "\nbead_radius_clay = " << o.lj_bead_radius_clay
+                << "\natom_type = " << o.mmt_atom_type
+                << "\nmmt_edge_bond_type = " << o.mmt_edge_bond_type
+                << "\nmmt_diagonal_bond_type = " << o.mmt_diagonal_bond_type
+                << "\nx = " << x
+                << "\ny = " << y
+                << "\nz = " << z
+                << "\ncharged_count = " << charged_count
+                << "\nbead_charge = " << o.bead_charge
+                << "\n**********\n";
           }
         #endif
+
         std::vector<Atom> new_atoms;
         std::vector<Bond> new_bonds;
         size_t new_idx = 1;
+
         // Add atoms and bonds top-bottom
         std::map<int, std::map<int, std::map<std::string, size_t> > > atom_ids;
         for (int idxx = -(int)o.platelet_radius + 1; idxx < (int)o.platelet_radius;
             ++idxx)
           {
             atom_ids[idxx] = std::map<int, std::map<std::string, size_t> >();
-            float dx = idxx * 2 * o.lj_bead_radius;
+            float dx = idxx * 2 * o.lj_bead_radius_clay;
             for (int idxy = -(int)o.platelet_radius + 1;
                 idxy < (int)o.platelet_radius; ++idxy)
               {
@@ -120,11 +123,11 @@ public:
                     continue;
                   }
                 atom_ids[idxx][idxy] = std::map<std::string, size_t>();
-                float dy = idxy * 2 * o.lj_bead_radius;
-                new_atoms.push_back(Atom(x + dx, y + dy, z - o.lj_bead_radius,
+                float dy = idxy * 2 * o.lj_bead_radius_clay;
+                new_atoms.push_back(Atom(x + dx, y + dy, z - o.lj_bead_radius_clay,
                     0, o.mmt_atom_type, 0, 0, 0, "filler"));
                 atom_ids[idxx][idxy]["bottom"] = new_idx;
-                new_atoms.push_back(Atom(x + dx, y + dy, z + o.lj_bead_radius,
+                new_atoms.push_back(Atom(x + dx, y + dy, z + o.lj_bead_radius_clay,
                     0, o.mmt_atom_type, 0, 0, 0, "filler"));
                 atom_ids[idxx][idxy]["top"] = new_idx + 1;
                 new_bonds.push_back(Bond(o.mmt_edge_bond_type, new_idx,
@@ -132,6 +135,7 @@ public:
                 new_idx += 2;
               }
           }
+
         // Add other bonds
         for (auto itx = atom_ids.begin(); itx != atom_ids.end(); ++itx)
           {
@@ -196,6 +200,7 @@ public:
                   }
               }
           }
+
         // Assign (or not) charges
         if (charged_count != 0)
           {
@@ -214,7 +219,7 @@ public:
                 new_atoms[*it].q = -o.bead_charge;
               }
           }
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Results of MMT addition
           {
             std::cout << "**********\n";
             std::cout << "MMT addition in structure.hpp:\n";
@@ -223,8 +228,8 @@ public:
             std::cout << "**********\n";
           }
         #endif
-        // Append created structure to the existing structure
-        std::cout << "Old atoms count\n" << this->_atoms_count << "\n";
+
+        // Append created structure into the existing structure
         for (size_t idx = 0; idx < new_bonds.size(); ++idx)
           {
             new_bonds[idx].atom_one += this->_atoms_count;
@@ -241,46 +246,47 @@ public:
       };
 
 
+    // Add an isolated MMT platelet
     bool add_mmt_periodic(OptionsPeriodic &o, float z=0, size_t charged_count=0)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print parameters of MMT addition
           {
-            std::cout << "**********\n";
-            std::cout << "Structure.hpp add_mmt_periodic input parameters:\n";
-            std::cout << "platelet_edge = " << o.platelet_edge << std::endl;
-            std::cout << "bead_radius = " << o.lj_bead_radius << std::endl;
-            std::cout << "atom_type = " << o.mmt_atom_type << std::endl;
-            std::cout << "mmt_edge_bond_type = " << o.mmt_edge_bond_type
-                << std::endl;
-            std::cout << "mmt_diagonal_bond_type = " << o.mmt_diagonal_bond_type
-               << std::endl;
-            std::cout << "z = " << z << std::endl;
-            std::cout << "charged_count = " << charged_count << std::endl;
-            std::cout << "bead_charge = " << o.bead_charge << std::endl;
-            std::cout << "**********\n";
+            std::cout << "**********\n"
+                << "Structure.hpp add_mmt_periodic input parameters:\n"
+                << "platelet_edge = " << o.platelet_edge
+                << "\nbead_radius_clay = " << o.lj_bead_radius_clay
+                << "\natom_type = " << o.mmt_atom_type
+                << "\nmmt_edge_bond_type = " << o.mmt_edge_bond_type
+                << "\nmmt_diagonal_bond_type = " << o.mmt_diagonal_bond_type
+                << "\nz = " << z
+                << "\ncharged_count = " << charged_count
+                << "\nbead_charge = " << o.bead_charge
+                << "\n**********\n";
           }
         #endif
+
         std::vector<Atom> new_atoms;
         std::vector<Bond> new_bonds;
         size_t new_idx = 1;
+
         // Add atoms and bonds top-bottom
         std::map<int, std::map<int, std::map<std::string, size_t> > > atom_ids;
         for (int idxx = 0; idxx < (int)o.platelet_edge; ++idxx)
           {
             atom_ids[idxx] = std::map<int, std::map<std::string, size_t> >();
-            float dx = idxx * 2 * o.lj_bead_radius
-                       - (float)o.platelet_edge * o.lj_bead_radius
-                       + o.lj_bead_radius;
+            float dx = idxx * 2 * o.lj_bead_radius_clay
+                       - (float)o.platelet_edge * o.lj_bead_radius_clay
+                       + o.lj_bead_radius_clay;
             for (int idxy = 0; idxy < (int)o.platelet_edge; ++idxy)
               {
                 atom_ids[idxx][idxy] = std::map<std::string, size_t>();
-                float dy = idxy * 2 * o.lj_bead_radius
-                           - (float)o.platelet_edge * o.lj_bead_radius
-                           + o.lj_bead_radius;
-                new_atoms.push_back(Atom(dx, dy, z - o.lj_bead_radius,
+                float dy = idxy * 2 * o.lj_bead_radius_clay
+                           - (float)o.platelet_edge * o.lj_bead_radius_clay
+                           + o.lj_bead_radius_clay;
+                new_atoms.push_back(Atom(dx, dy, z - o.lj_bead_radius_clay,
                     0, o.mmt_atom_type, 0, 0, 0, "filler"));
                 atom_ids[idxx][idxy]["bottom"] = new_idx++;
-                new_atoms.push_back(Atom(dx, dy, z + o.lj_bead_radius,
+                new_atoms.push_back(Atom(dx, dy, z + o.lj_bead_radius_clay,
                     0, o.mmt_atom_type, 0, 0, 0, "filler"));
                 atom_ids[idxx][idxy]["top"] = new_idx++;
                 // Only bonds top-bottom
@@ -288,6 +294,7 @@ public:
                     new_idx - 1));
               }
           }
+
         // Add other bonds
         for (auto idx_x = 0; idx_x < (int)o.platelet_edge; ++idx_x)
           {
@@ -384,6 +391,7 @@ public:
                   }
               }
           }
+
         // Assign (or not) charges
         if (charged_count != 0)
           {
@@ -402,7 +410,7 @@ public:
                 new_atoms[*it].q = -o.bead_charge;
               }
           }
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Results of MMT addition
           {
             std::cout << "**********\n";
             std::cout << "MMT addition in structure.hpp:\n";
@@ -411,8 +419,8 @@ public:
             std::cout << "**********\n";
           }
         #endif
+
         // Append created structure to the existing structure
-        std::cout << "Old atoms count\n" << this->_atoms_count << "\n";
         for (size_t idx = 0; idx < new_bonds.size(); ++idx)
           {
             new_bonds[idx].atom_one += this->_atoms_count;
@@ -428,50 +436,49 @@ public:
         return true;
       };
 
+
+    // Add modifier into the space sconstrained by z = top and z = bottom
     bool add_modifier_gallery(OptionsCommon &o, float top, float bottom)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Parameters of modifier addition
           {
-            std::cout << "**********\n";
-            std::cout << "Structure.hpp add_modifier_gallery input parameters:\n";
-            std::cout << "tail_length = " << o.tail_length << std::endl;
-            //std::cout << "planar_expansion_coeff = " << o.planar_expansion_coeff
-            //    << std::endl;
-            std::cout << "modifier_head_tail_bond_length = "
-                << o.modifier_head_tail_bond_length << std::endl;
-            std::cout << "modifier_tail_tail_bond_length = "
-                << o.modifier_tail_tail_bond_length << std::endl;
-            std::cout << "lj_bead_radius = " << o.lj_bead_radius << std::endl;
-            std::cout << "too_close_threshold_mmt = " << o.too_close_threshold_mmt
-                << std::endl;
-            std::cout << "too_close_threshold_soft = " << o.too_close_threshold_soft
-                << std::endl;
-            std::cout << "modifier_head_atom_type = " << o.modifier_head_atom_type
-                << std::endl;
-            std::cout << "modifier_tail_atom_type = " << o.modifier_tail_atom_type
-                << std::endl;
-            std::cout << "bead_charge = " << o.bead_charge << std::endl;
-            std::cout << "head_tail_type = " << o.head_tail_type << std::endl;
-            std::cout << "tail_tail_type = " << o.tail_tail_type << std::endl;
-            std::cout << "top = " << top << std::endl;
-            std::cout << "bottom = " << bottom << std::endl;
-            std::cout << "**********\n";
+            std::cout << "**********\n"
+                << "Structure.hpp add_modifier_gallery input parameters:\n"
+                << "tail_length = " << o.tail_length
+                // << "\nplanar_expansion_coeff = " << o.planar_expansion_coeff
+                << "\nmodifier_head_tail_bond_length = "
+                    << o.modifier_head_tail_bond_length
+                << "\nmodifier_tail_tail_bond_length = "
+                    << o.modifier_tail_tail_bond_length
+                << "\nlj_bead_radius_soft = " << o.lj_bead_radius_soft
+                << "\ntoo_close_threshold_mmt = " << o.too_close_threshold_mmt
+                << "\ntoo_close_threshold_soft = " << o.too_close_threshold_soft
+                << "\nmodifier_head_atom_type = " << o.modifier_head_atom_type
+                << "\nmodifier_tail_atom_type = " << o.modifier_tail_atom_type
+                << "\nbead_charge = " << o.bead_charge
+                << "\nhead_tail_type = " << o.head_tail_type
+                << "\ntail_tail_type = " << o.tail_tail_type
+                << "\ntop = " << top
+                << "\nbottom = " << bottom
+                << "\n**********\n";
           }
         #endif
+
         srand(time(NULL));
         float lx = this->xhi - this->xlo;
         float ly = this->yhi - this->ylo;
         float lz = this->zhi - this->zlo;
         float interlayer = top - bottom;
         size_t fails_done = 0;
+
         // TODO adjust fails allowed
         size_t fails_allowed = 100;
         std::vector<Atom> new_atoms;
         std::vector<Bond> new_bonds;
         float close_r_sq_mmt = pow(o.too_close_threshold_mmt, 2)
-                               * pow(o.lj_bead_radius, 2);
+                               * pow(o.lj_bead_radius_soft, 2);
         float close_r_sq_soft = pow(o.too_close_threshold_soft, 2)
-                                * pow(o.lj_bead_radius, 2);
+                                * pow(o.lj_bead_radius_soft, 2);
         while (fails_done < fails_allowed
                && new_atoms.size() != 1 + o.tail_length)
           {
@@ -483,10 +490,9 @@ public:
                 float x_coeff = (float)(rand()) / (float)(RAND_MAX) - 0.5;
                 float y_coeff = (float)(rand()) / (float)(RAND_MAX) - 0.5;
                 float z_coeff = (float)(rand()) / (float)(RAND_MAX);
-                // TODO Why division was here?
                 //x = this->xlo + lx/2 + lx/2 * o.planar_expansion_coeff * x_coeff;
                 //y = this->ylo + ly/2 + ly/2 * o.planar_expansion_coeff * y_coeff;
-                x = this->xlo + lx/2 + lx/4 * x_coeff;
+                x = this->xlo + lx/2 + lx/4 * x_coeff;  // planar coeff == 2
                 y = this->ylo + ly/2 + ly/4 * y_coeff;
                 z = bottom + interlayer * z_coeff;
               }
@@ -503,11 +509,11 @@ public:
             float r;
             if (new_atoms.size() == 0)
               {
-                r = o.modifier_head_tail_bond_length * o.lj_bead_radius;
+                r = o.modifier_head_tail_bond_length * o.lj_bead_radius_soft;
               }
             else
               {
-                r = o.modifier_tail_tail_bond_length * o.lj_bead_radius;
+                r = o.modifier_tail_tail_bond_length * o.lj_bead_radius_soft;
               }
             x += r * sin(theta) * cos(phi);
             y += r * sin(theta) * sin(phi);
@@ -590,44 +596,38 @@ public:
         return true;
       }
 
+
+    // Add polymer to the system
     bool add_polymer(OptionsCommon &o)
       {
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print parameters of polymer addition
         if (false)
           {
-            std::cout << "**********\n";
-            std::cout << "Structure.hpp add_polymer input parameters:\n";
-            std::cout << "polymer_bond_length = " << o.polymer_bond_length
-                << std::endl;
-            std::cout << "lj_bead_radius = " << o.lj_bead_radius << std::endl;
-            std::cout << "too_close_threshold_mmt = "
-                << o.too_close_threshold_mmt << std::endl;
-            std::cout << "too_close_threshold_soft = "
-                << o.too_close_threshold_soft << std::endl;
-            std::cout << "polymer_atom_type = " << o.polymer_atom_type
-                << std::endl;
-            std::cout << "polymer_bond_type = " << o.polymer_bond_type
-                << std::endl;
-            std::cout << "polymerization = " << o.polymerization << std::endl;
+            std::cout << "**********\n"
+                << "Structure.hpp add_polymer input parameters:\n"
+                << "\npolymer_bond_length = " << o.polymer_bond_length
+                << "\nlj_bead_radius = " << o.lj_bead_radius_soft
+                << "\ntoo_close_threshold_mmt = " << o.too_close_threshold_mmt
+                << "\ntoo_close_threshold_soft = " << o.too_close_threshold_soft
+                << "\npolymer_atom_type = " << o.polymer_atom_type
+                << "\npolymer_bond_type = " << o.polymer_bond_type
+                << "\npolymerization = " << o.polymerization << std::endl;
           }
         #endif
+
         srand(time(NULL));
         float lx = this->xhi - this->xlo;
         float ly = this->yhi - this->ylo;
         float lz = this->zhi - this->zlo;
         size_t fails_done = 0;
         // TODO adjust fails allowed
-        // This parameter is important since it seems to affect
-        // on resulting dpd density strongly compared to attempts number
-        // in main function (periodic.cpp).
         size_t fails_allowed = 500;
         std::vector<Atom> new_atoms;
         std::vector<Bond> new_bonds;
         float close_r_sq_mmt = pow(o.too_close_threshold_mmt, 2)
-                               * pow(o.lj_bead_radius, 2);
-        // Important parameter, stronly affects on resulting density
+                               * pow(o.lj_bead_radius_soft, 2);
         float close_r_sq_soft = pow(o.too_close_threshold_soft, 2)
-                                * pow(o.lj_bead_radius, 2);
+                                * pow(o.lj_bead_radius_soft, 2);
         while (fails_done < fails_allowed
                && new_atoms.size() != o.polymerization)
           {
@@ -653,7 +653,7 @@ public:
             float phi_coeff = (float)(rand()) / (float)(RAND_MAX);
             float theta = theta_coeff * M_PI;
             float phi = phi_coeff * 2*M_PI;
-            float r = o.polymer_bond_length * o.lj_bead_radius;
+            float r = o.polymer_bond_length * o.lj_bead_radius_soft;
             x += r * sin(theta) * cos(phi);
             y += r * sin(theta) * sin(phi);
             z += r * cos(theta);
@@ -705,7 +705,6 @@ public:
           }
         if (new_atoms.size() != o.polymerization)
           {
-            //std::cout << "short\n";
             return false;
           }
         for (size_t idx = 0; idx < new_atoms.size(); ++idx)
@@ -725,16 +724,15 @@ public:
       }
 
 
+    // Parallel version of polymer addition.
+    // Crops whole box into nx*ny*nz parallelepipeds and inserts
+    // polymer chains into the parallelepiped that is defined by:
+    //     0 <= idx_x < nx
+    //     0 <= idx_y < ny
+    //     0 <= idx_z < nz
     bool add_polymer_parallel(OptionsIsolatedParallel &o,
         size_t idx_x, size_t nx, size_t idx_y, size_t ny, size_t idx_z, size_t nz)
       {
-        /* Crops whole box into nx*ny*nz parallelepipeds and inserts
-           polymer chains into the parallelepiped that is defined by:
-           0 <= idx_x < nx
-           0 <= idx_y < ny
-           0 <= idx_z < nz
-        */
-
         srand(time(NULL));
         float lx = (this->xhi - this->xlo) / nx;
         float ly = (this->yhi - this->ylo) / ny;
@@ -747,38 +745,29 @@ public:
         float my_zhi = this->zlo + lz * (idx_z + 1);
         size_t fails_done = 0;
 
-        #ifdef DEBUG
+        #ifdef DETAILED_OUTPUT  // Print parameters of polmyer addition
         if (false)
           {
-            std::cout << "**********\n";
-            std::cout << "Structure.hpp add_polymer input parameters:\n";
-            std::cout << "polymer_bond_length = " << o.polymer_bond_length
-                << std::endl;
-            std::cout << "lj_bead_radius = " << o.lj_bead_radius << std::endl;
-            std::cout << "too_close_threshold_mmt = "
-                << o.too_close_threshold_mmt << std::endl;
-            std::cout << "too_close_threshold_soft = "
-                << o.too_close_threshold_soft << std::endl;
-            std::cout << "polymer_atom_type = " << o.polymer_atom_type
-                << std::endl;
-            std::cout << "polymer_bond_type = " << o.polymer_bond_type
-                << std::endl;
-            std::cout << "polymerization = " << o.polymerization << std::endl;
+            std::cout << "**********\n"
+                << "Structure.hpp add_polymer input parameters:\n"
+                << "polymer_bond_length = " << o.polymer_bond_length
+                << "\nlj_bead_radius_soft = " << o.lj_bead_radius_soft
+                << "\ntoo_close_threshold_mmt = " << o.too_close_threshold_mmt
+                << "too_close_threshold_soft = " << o.too_close_threshold_soft
+                << "polymer_atom_type = " << o.polymer_atom_type
+                << "polymer_bond_type = " << o.polymer_bond_type
+                << "polymerization = " << o.polymerization << std::endl;
           }
         #endif
 
         // TODO adjust fails allowed
-        // This parameter is important since it seems to affect
-        // on resulting dpd density strongly compared to attempts number
-        // in main function (periodic.cpp).
         size_t fails_allowed = 500;
         std::vector<Atom> new_atoms;
         std::vector<Bond> new_bonds;
         float close_r_sq_mmt = pow(o.too_close_threshold_mmt, 2)
-                               * pow(o.lj_bead_radius, 2);
-        // Important parameter, stronly affects on resulting density
+                               * pow(o.lj_bead_radius_soft, 2);
         float close_r_sq_soft = pow(o.too_close_threshold_soft, 2)
-                                * pow(o.lj_bead_radius, 2);
+                                * pow(o.lj_bead_radius_soft, 2);
         while (fails_done < fails_allowed
                && new_atoms.size() != o.polymerization)
           {
@@ -804,7 +793,7 @@ public:
             float phi_coeff = (float)(rand()) / (float)(RAND_MAX);
             float theta = theta_coeff * M_PI;
             float phi = phi_coeff * 2*M_PI;
-            float r = o.polymer_bond_length * o.lj_bead_radius;
+            float r = o.polymer_bond_length * o.lj_bead_radius_soft;
             x += r * sin(theta) * cos(phi);
             y += r * sin(theta) * sin(phi);
             z += r * cos(theta);

--- a/src/structure.hpp
+++ b/src/structure.hpp
@@ -12,7 +12,11 @@
 #include <string>
 #include <vector>
 
-class Options;
+#include "options_common.hpp"
+#include "options_periodic.hpp"
+#include "options_isolated.hpp"
+#include "options_isolated_parallel.hpp"
+//class Options;
 
 
 struct Atom
@@ -76,7 +80,7 @@ public:
         return this->_bonds;
       }
 
-    bool add_mmt_circular(Options &o,
+    bool add_mmt_circular(OptionsIsolated &o,
         float x=0, float y=0, float z=0, size_t charged_count=0)
       {
         #ifdef DEBUG
@@ -237,7 +241,7 @@ public:
       };
 
 
-    bool add_mmt_periodic(Options &o, float z=0, size_t charged_count=0)
+    bool add_mmt_periodic(OptionsPeriodic &o, float z=0, size_t charged_count=0)
       {
         #ifdef DEBUG
           {
@@ -424,15 +428,15 @@ public:
         return true;
       };
 
-    bool add_modifier_gallery(Options &o, float top, float bottom)
+    bool add_modifier_gallery(OptionsCommon &o, float top, float bottom)
       {
         #ifdef DEBUG
           {
             std::cout << "**********\n";
             std::cout << "Structure.hpp add_modifier_gallery input parameters:\n";
             std::cout << "tail_length = " << o.tail_length << std::endl;
-            std::cout << "planar_expansion_coeff = " << o.planar_expansion_coeff
-                << std::endl;
+            //std::cout << "planar_expansion_coeff = " << o.planar_expansion_coeff
+            //    << std::endl;
             std::cout << "modifier_head_tail_bond_length = "
                 << o.modifier_head_tail_bond_length << std::endl;
             std::cout << "modifier_tail_tail_bond_length = "
@@ -480,8 +484,10 @@ public:
                 float y_coeff = (float)(rand()) / (float)(RAND_MAX) - 0.5;
                 float z_coeff = (float)(rand()) / (float)(RAND_MAX);
                 // TODO Why division was here?
-                x = this->xlo + lx/2 + lx/2 * o.planar_expansion_coeff * x_coeff;
-                y = this->ylo + ly/2 + ly/2 * o.planar_expansion_coeff * y_coeff;
+                //x = this->xlo + lx/2 + lx/2 * o.planar_expansion_coeff * x_coeff;
+                //y = this->ylo + ly/2 + ly/2 * o.planar_expansion_coeff * y_coeff;
+                x = this->xlo + lx/2 + lx/4 * x_coeff;
+                y = this->ylo + ly/2 + ly/4 * y_coeff;
                 z = bottom + interlayer * z_coeff;
               }
             else
@@ -584,7 +590,7 @@ public:
         return true;
       }
 
-    bool add_polymer(Options &o)
+    bool add_polymer(OptionsCommon &o)
       {
         #ifdef DEBUG
         if (false)
@@ -719,7 +725,7 @@ public:
       }
 
 
-    bool add_polymer_parallel(Options &o,
+    bool add_polymer_parallel(OptionsIsolatedParallel &o,
         size_t idx_x, size_t nx, size_t idx_y, size_t ny, size_t idx_z, size_t nz)
       {
         /* Crops whole box into nx*ny*nz parallelepipeds and inserts

--- a/util_lmp_in_writer.py
+++ b/util_lmp_in_writer.py
@@ -52,9 +52,10 @@ def write(fname='py_lmp_in', **kwargs):
     tmppr('pair_style    hybrid/overlay coul/cut {0} dpd 1 {1} {2}'.format(
         kwargs['pair_radius'], kwargs['dpd_cutoff'], random.randint(1, 100000000)))
     tmppr('')
+
     # a_ij,  gamma, r_ij
-    tmppr('pair_coeff    1 1 dpd {0} {1}'.format(kwargs['a_cl_cl'],
-        kwargs['gamma']))
+    tmppr('pair_coeff    1 1 dpd {0} {1} {2}'.format(kwargs['a_cl_cl'],
+        kwargs['gamma'], kwargs['r_cl']))
     tmppr('pair_coeff    1 2 dpd {0} {1} {2}'.format(kwargs['a_cl_mh'],
         kwargs['gamma'], (kwargs['r_cl'] + kwargs['r_mh'])/2))
     tmppr('pair_coeff    1 3 dpd {0} {1} {2}'.format(kwargs['a_cl_mt'],
@@ -108,23 +109,21 @@ if __name__ == '__main__':
     ###############
     # some test parameters
 
-    big_a = 100
+    big_a = 100    # bead repulsion constants
     small_a = 1
 
-    big_k = 100
+    big_k = 100    # bond energy constants
     small_k = 10
 
-    pair_radius = 7
-    dpd_cutoff = 2
+    pair_radius = 15    # Coulomb interaction cutoff
+    dpd_cutoff = 1    # lj_r_c
 
-    big_r = 1.72
-    small_r = 1.72
+    soft_r = 0.7     # soft beads DPD radius
+    clay_r = 1.72    # clay beads DPD radius
 
     ###############
 
     kwargs = {
-        'data_fname':   'periodic_composite.data',
-
         'pair_radius':  pair_radius,
         'dpd_cutoff':   dpd_cutoff,
 
@@ -152,10 +151,12 @@ if __name__ == '__main__':
 
         'gamma':        5,
 
-        'r_cl':         big_r,
-        'r_mh':         small_r,
-        'r_mt':         small_r,
-        'r_po':         small_r,
+        'r_cl':         clay_r,
+        'r_mh':         soft_r,
+        'r_mt':         soft_r,
+        'r_po':         soft_r,
     }
+
+    kwargs['data_fname'] = 'isolated_mmt_r3_n2_mod_n4_tail5_poly_p10_n162.data'
 
     write(**kwargs)


### PR DESCRIPTION
The last used version was here:
https://github.com/ansko/dpd_tools_cpp/commit/fb08065a683e6641809897c77e464946a9994337

It was incorrect:
- now bead radii for clay and soft differ (both py and cpp)
- DPD cutoff significantly increased
- DPD rho seems to be correct (even though beads count is almost the same as previously)

This version seems to be ok, but is poorly tested.